### PR TITLE
Update PipeLine.py

### DIFF
--- a/resources/libs/PipeLine.py
+++ b/resources/libs/PipeLine.py
@@ -74,6 +74,7 @@ class PipeLine:
                 "aml020t":  Display.AML020T,
                 "jd9852":   Display.JD9852,
                 "ili9806":  Display.ILI9806,
+                "virt":     Display.VIRT,
             }
 
             # Look up type, fallback to ST7701 if not found


### PR DESCRIPTION
Allow to run PipeLine with only virtual display.

Currently when I try to run for example the "face detection" example on k230D zero without any display connected, the error "RuntimeError: init panel failed" is thrown (PipeLine.py line 94).

Adding Display.VIRT to the display map in PipeLine.py allows to specify "virt" as display_mode to only use the virtual display of CanVM IDE.